### PR TITLE
GNOME runtime 41, deleted --socket=x11

### DIFF
--- a/im.fluffychat.Fluffychat.json
+++ b/im.fluffychat.Fluffychat.json
@@ -7,7 +7,6 @@
     "separate-locales": false,
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
         "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",

--- a/im.fluffychat.Fluffychat.json
+++ b/im.fluffychat.Fluffychat.json
@@ -1,7 +1,7 @@
 {
     "app-id": "im.fluffychat.Fluffychat",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "40",
+    "runtime-version": "41",
     "sdk": "org.gnome.Sdk",
     "command": "fluffychat",
     "separate-locales": false,


### PR DESCRIPTION
Updated GNOME runtime to 41, deleted --socket=x11 (unneeded with --socket=fallback-x11)