### PR TITLE
stop botto finding betas

### DIFF
--- a/im.fluffychat.Fluffychat.json
+++ b/im.fluffychat.Fluffychat.json
@@ -75,8 +75,8 @@
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://gitlab.com/api/v4/projects/famedly%2Ffluffychat/releases/",
-                        "version-query": ".[0] | .tag_name | sub(\"v\";\"\")",
-                        "url-query": ".[0] | .assets  | .links[] | select(.name==\"fluffychat-linux-x86.tar.gz\") | .url"
+                        "version-query": "first(.[] | select(.tag_name|startswith(\"v\"))) | .tag_name | sub(\"v\";\"\")",
+                        "url-query": "first(.[] | select(.tag_name|startswith(\"v\")))  | .assets.links[] | select(.name==\"fluffychat-linux-x86.tar.gz\") | .url"
                     }
                 },
                 {
@@ -90,8 +90,8 @@
                     "x-checker-data": {
                         "type": "json",
                         "url": "https://gitlab.com/api/v4/projects/famedly%2Ffluffychat/releases/",
-                        "version-query": ".[0] | .tag_name | sub(\"v\";\"\")",
-                        "url-query": ".[0] | .assets  | .links[] | select(.name==\"fluffychat-linux-arm64.tar.gz\") | .url"
+                        "version-query": "first(.[] | select(.tag_name|startswith(\"v\"))) | .tag_name | sub(\"v\";\"\")",
+                        "url-query": "first(.[] | select(.tag_name|startswith(\"v\"))) | .assets.links[] | select(.name==\"fluffychat-linux-arm64.tar.gz\") | .url"
                     }
                 },
                 {


### PR DESCRIPTION
botto kept opening naughty merge requests this should hopefully make it only find stable versions? a slight modification of this could maybe be done on a beta branch