### PR TITLE
Remove x11 socket

### DIFF
--- a/im.fluffychat.Fluffychat.json
+++ b/im.fluffychat.Fluffychat.json
@@ -7,7 +7,6 @@
     "separate-locales": false,
     "finish-args": [
         "--share=ipc",
-        "--socket=x11",
         "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",


### PR DESCRIPTION
If your application supports wayland and fallback-x11 is exposed, the x11 is socket is not needed.

https://github.com/flathub/flathub/issues/1452