### PR TITLE
update to current GNOME runtime version 49

### DIFF
--- a/im.fluffychat.Fluffychat.json
+++ b/im.fluffychat.Fluffychat.json
@@ -1,7 +1,7 @@
 {
     "app-id": "im.fluffychat.Fluffychat",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "46",
+    "runtime-version": "49",
     "sdk": "org.gnome.Sdk",
     "command": "fluffychat",
     "separate-locales": false,


### PR DESCRIPTION
GNOME 46 is already end-of-life.