### PR TITLE
metainfo: Make Fluffychat part of Flathub's Mobile collection

### DIFF
--- a/im.fluffychat.Fluffychat.metainfo.xml
+++ b/im.fluffychat.Fluffychat.metainfo.xml
@@ -10,6 +10,9 @@
     <control>keyboard</control>
     <control>touch</control>
   </recommends>
+  <requires>
+    <display_length compare="ge">300</display_length>
+  </requires>
   <developer_name>fluffychat.im</developer_name>
   <url type="homepage">https://fluffychat.im</url>
   <description>


### PR DESCRIPTION
Hi, 
thanks for creating Fluffychat and packaging it up on Flathub!
This PR makes Fluffychat a part of [Flathub's Mobile Collection](https://flathub.org/en/apps/collection/mobile/1).

See https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/\#desktop-and-mobile-apps for further information.

Cheers,
Peter
